### PR TITLE
packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: go get .
 
       - name: Run tests
-        run: go test .
+        run: go test ./...
 
       - name: Build binaries
         # no need to build binaries if a release is going to be made.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: build
+          args: build --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: Repo Pack CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Golang
+        uses: actions/setup-go@v5
+        with:
+          cache-dependency-path: go.sum
+
+      - name: Install dependencies
+        run: go get .
+
+      - name: Run tests
+        run: go test .
+
+      - name: Build binaries
+        # no need to build binaries if a release is going to be made.
+        if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: dist/*
+
+  release:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: ['test']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Golang
+        uses: actions/setup-go@v4
+        with:
+          cache-dependency-path: go.sum
+
+      - name: Install dependencies
+        run: go get .
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ tests/
 
 # build file
 repo-pack
+
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ tests/
 repo-pack
 
 dist/
+
+.DS_Store

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,16 +27,22 @@ archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
-      {{ .ProjectName }}-
-      {{- title .Os }}-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
     # use zip for windows archives
     format_overrides:
       - goos: windows
         format: zip
+
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,44 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 1
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+
+report_sizes: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,8 +27,8 @@ archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
+      {{ .ProjectName }}-
+      {{- title .Os }}-
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}

--- a/helpers/parse_test.go
+++ b/helpers/parse_test.go
@@ -1,0 +1,60 @@
+package helpers_test
+
+import (
+	"repo-pack/helpers"
+	"repo-pack/model"
+	"testing"
+)
+
+func TestParseRepoValidURL(t *testing.T) {
+	url := "https://github.com/owner/repo/tree/main/dir"
+	expected := model.RepoURLComponents{
+		Owner:      "owner",
+		Repository: "repo",
+		Ref:        "main",
+		Dir:        "dir",
+	}
+
+	components, err := helpers.ParseRepoURL(url)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if components != expected {
+		t.Errorf("expected components: %+v, got: %+v", expected, components)
+	}
+}
+
+func TestParseRepoInvalidURL(t *testing.T) {
+	url := "invalid-url"
+	expected := model.RepoURLComponents{}
+	expectedErr := "invalid URL format: invalid-url"
+
+	components, err := helpers.ParseRepoURL(url)
+	if err == nil {
+		t.Errorf("expected error: %s, got: nil", expectedErr)
+	} else if err.Error() != expectedErr {
+		t.Errorf("expected error: %s, got: %v", expectedErr, err)
+	}
+
+	if components != expected {
+		t.Errorf("expected components: %+v, got: %+v", expected, components)
+	}
+}
+
+func TestParseRepoInvalidURLFormat(t *testing.T) {
+	url := "https://github.com/owner/repo/blob/main/file.txt"
+	expected := model.RepoURLComponents{}
+	expectedErr := "invalid URL format: https://github.com/owner/repo/blob/main/file.txt"
+
+	components, err := helpers.ParseRepoURL(url)
+	if err == nil {
+		t.Errorf("expected error: %s, got: nil", expectedErr)
+	} else if err.Error() != expectedErr {
+		t.Errorf("expected error: %s, got: %v", expectedErr, err)
+	}
+
+	if components != expected {
+		t.Errorf("expected components: %+v, got: %+v", expected, components)
+	}
+}

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,47 @@
+# Set the repository and binary name
+$REPO = "stemitom/repo-pack"
+$BINARY_NAME = "repo-pack"
+
+# Colors
+$RED = [System.ConsoleColor]::Red
+$GREEN = [System.ConsoleColor]::Green
+$YELLOW = [System.ConsoleColor]::Yellow
+$BLUE = [System.ConsoleColor]::Blue
+$NC = [System.ConsoleColor]::White
+
+# Check if the binary exists and delete it
+if (Test-Path "C:\Program Files\$BINARY_NAME.exe") {
+    Write-Host "Removing existing $BINARY_NAME binary..." -ForegroundColor $YELLOW
+    Remove-Item "C:\Program Files\$BINARY_NAME.exe"
+}
+
+Write-Host "Getting the latest release information..." -ForegroundColor $BLUE
+$LATEST_VERSION = (Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest").tag_name
+
+Write-Host "Getting the machine architecture..." -ForegroundColor $BLUE
+$ARCH = $env:PROCESSOR_ARCHITECTURE
+$KERNEL = "Windows"
+
+Write-Host "Downloading the binary..." -ForegroundColor $GREEN
+$DOWNLOAD_URL = "https://github.com/$REPO/releases/download/$LATEST_VERSION/${BINARY_NAME}-${KERNEL}-${ARCH}.zip"
+Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile "${BINARY_NAME}.zip"
+
+Write-Host "Extracting the binary..." -ForegroundColor $GREEN
+Expand-Archive -Path "${BINARY_NAME}.zip"
+
+Write-Host "Making the binary executable..." -ForegroundColor $GREEN
+
+Write-Host "Install the binary? (y/n) " -ForegroundColor $YELLOW -NoNewline
+$INSTALL = Read-Host
+
+if ($INSTALL -eq "y") {
+    Write-Host "Installing the binary..." -ForegroundColor $GREEN
+    Move-Item -Path "${BINARY_NAME}.exe" -Destination "C:\Program Files\"
+} else {
+    Write-Host "Skipping installation..." -ForegroundColor $RED
+}
+
+Write-Host "Cleaning up..." -ForegroundColor $GREEN
+Remove-Item "${BINARY_NAME}.zip"
+
+Write-Host "Done!" -ForegroundColor $GREEN

--- a/install.ps1
+++ b/install.ps1
@@ -23,7 +23,7 @@ $ARCH = $env:PROCESSOR_ARCHITECTURE
 $KERNEL = "Windows"
 
 Write-Host "Downloading the binary..." -ForegroundColor $GREEN
-$DOWNLOAD_URL = "https://github.com/$REPO/releases/download/$LATEST_VERSION/${BINARY_NAME}-${KERNEL}-${ARCH}.zip"
+$DOWNLOAD_URL = "https://github.com/$REPO/releases/download/$LATEST_VERSION/${BINARY_NAME}_${KERNEL}_${ARCH}.zip"
 Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile "${BINARY_NAME}.zip"
 
 Write-Host "Extracting the binary..." -ForegroundColor $GREEN

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# Set the repository and binary name
+REPO="stemitom/repo-pack"
+BINARY_NAME="repo-pack"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Check if the binary exists and delete it
+if [ -f "/usr/local/bin/${BINARY_NAME}" ]; then
+    echo -e "${YELLOW}Removing existing ${BINARY_NAME} binary...${NC}"
+    sudo rm "/usr/local/bin/${BINARY_NAME}"
+fi
+
+echo "${BLUE}Getting the latest release information...${NC}"
+LATEST_VERSION=$(curl -s https://api.github.com/repos/${REPO}/releases/latest | grep -o '"tag_name": ".*"' | awk -F'"' '{print $4}')
+
+echo "${BLUE}Getting the machine architecture...${NC}"
+ARCH=$(uname -m)
+KERNEL=$(uname -s)
+
+echo "${GREEN}Downloading the binary...${NC}"
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST_VERSION}/${BINARY_NAME}-${KERNEL}-${ARCH}.tar.gz"
+curl -# -L -o "${BINARY_NAME}.tar.gz" "${DOWNLOAD_URL}"
+
+echo "${GREEN}Extracting the binary...${NC}"
+tar -xzf "${BINARY_NAME}.tar.gz"
+
+echo "${GREEN}Making the binary executable...${NC}"
+chmod +x "${BINARY_NAME}"
+
+printf "${YELLOW}Install the binary? (y/n) ${NC}"
+read -r INSTALL </dev/tty
+
+if [ "$INSTALL" = "y" ]; then
+    echo "${GREEN}Installing the binary...${NC}"
+    sudo mv "${BINARY_NAME}" /usr/local/bin/
+else
+    echo "${RED}Skipping installation...${NC}"
+fi
+
+echo "${GREEN}Cleaning up...${NC}"
+rm "${BINARY_NAME}.tar.gz"
+
+echo "${GREEN}Done!${NC}"

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ ARCH=$(uname -m)
 KERNEL=$(uname -s)
 
 echo "${GREEN}Downloading the binary...${NC}"
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST_VERSION}/${BINARY_NAME}-${KERNEL}-${ARCH}.tar.gz"
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST_VERSION}/${BINARY_NAME}_${KERNEL}_${ARCH}.tar.gz"
 curl -# -L -o "${BINARY_NAME}.tar.gz" "${DOWNLOAD_URL}"
 
 echo "${GREEN}Extracting the binary...${NC}"


### PR DESCRIPTION
Having to clone the repository and then build the application just to use this package is somewhat inconvenient.

So, this PR aims to fix(i think) that by making the following improvements:
- Adds a dummy test suite.
- Adds a `build` job that releases a binary whenever there's a tag push.
- Provides a script(for windows, linux and macOS) for easy installation.

A follow up PR/commit will be to update the installation section of the readme.


P.S: I couldn't test the `install.ps1` script since I don't have a Windows machine.